### PR TITLE
workflow for creating issue report

### DIFF
--- a/.github/workflows/create-report.yaml
+++ b/.github/workflows/create-report.yaml
@@ -7,17 +7,13 @@ on:
         type: number
         default: 7
         description: The number of days to go back from today
-      dry-run:
-        type: boolean
-        default: false
-        description: Do not create the discussion item, just print the result
+
 env:
   DAYS_AGO: ${{ github.event.inputs.days-ago }}
   GH_TOKEN: ${{ github.token }}
   REPO_OWNER: ${{ github.repository_owner }}
   REPO_NAME: keri
   CATEGORY_SLUG: meetings
-  DRY_RUN: ${{ github.event.inputs.dry-run }}
 
 jobs:
   build:

--- a/.github/workflows/create-report.yaml
+++ b/.github/workflows/create-report.yaml
@@ -1,0 +1,28 @@
+name: Create issue and PR report
+
+on:
+  workflow_dispatch:
+    inputs:
+      days-ago:
+        type: number
+        default: 7
+        description: The number of days to go back from today
+      dry-run:
+        type: boolean
+        default: false
+        description: Do not create the discussion item, just print the result
+env:
+  DAYS_AGO: ${{ github.event.inputs.days-ago }}
+  GH_TOKEN: ${{ github.token }}
+  REPO_OWNER: ${{ github.repository_owner }}
+  REPO_NAME: keri
+  CATEGORY_SLUG: meetings
+  DRY_RUN: ${{ github.event.inputs.dry-run }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Print report
+        run: ./scripts/create-report.sh

--- a/scripts/create-report.sh
+++ b/scripts/create-report.sh
@@ -92,19 +92,15 @@ function create_discussion {
         }
     ')
 
-    if [ "${DRY_RUN}" = "true" ]; then
-        echo "$body"
-    else
-        gh api graphql -q '.data.createDiscussion.discussion.id' -F repoId="$repo_id" -F categoryId="$category_id" -F body="$body" -F title="$title" -f query='
-            mutation CreateDiscussion($repoId:ID!, $categoryId:ID!, $body:String!, $title:String!) {
-                createDiscussion(input: {repositoryId: $repoId, categoryId: $categoryId, body: $body, title: $title}) {
-                    discussion {
-                        id
-                    }
+    gh api graphql -q '.data.createDiscussion.discussion.id' -F repoId="$repo_id" -F categoryId="$category_id" -F body="$body" -F title="$title" -f query='
+        mutation CreateDiscussion($repoId:ID!, $categoryId:ID!, $body:String!, $title:String!) {
+            createDiscussion(input: {repositoryId: $repoId, categoryId: $categoryId, body: $body, title: $title}) {
+                discussion {
+                    id
                 }
             }
-        '
-    fi;
+        }
+    '
 }
 
 function create_discussion_comment {

--- a/scripts/create-report.sh
+++ b/scripts/create-report.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -e
+
+days=${DAYS_AGO:-8} # default to 8
+date=$(date --date="$days days ago" +"%Y-%m-%d")
+
+repo_owner=${REPO_OWNER:?"REPO_OWNER not set"}
+repo_name=${REPO_NAME:?"REPO_NAME not set"}
+category_slug=${CATEGORY_SLUG:?"CATEGORY_SLUG not set"}
+
+repos=(
+    "WebOfTrust/keripy"
+    "WebOfTrust/keria"
+    "WebOfTrust/signify-ts"
+    "WebOfTrust/signifypy"
+    "WebOfTrust/cesride"
+    "WebOfTrust/kerific"
+    "WebOfTrust/kerisse"
+    "WebOfTrust/keridoc"
+    "WebOfTrust/signify-browser-extension"
+    "WebOfTrust/polaris-web"
+)
+
+function create_report {
+    for p in "${repos[@]}"
+    do
+        issues=$(gh issue list --json url,title --repo "${p}" --search "created:>=$date sort:created-asc is:open" --template \
+            '{{range .}}{{"- "}}{{.url}}{{"\n"}}{{end}}')
+
+        open_prs=$(gh pr list --json url,title --repo "${p}" --search "created:>=$date sort:created-asc is:open" --template \
+            '{{range .}}{{"- "}}{{.url}}{{"\n"}}{{end}}')
+
+        merged_prs=$(gh pr list --json url,title --repo "${p}" --search "merged:>=$date sort:created-asc is:merged" --template \
+            '{{range .}}{{"- "}}{{.url}}{{"\n"}}{{end}}')
+
+        echo "# Repository ${p}"
+        echo ""
+        echo "## Issues created after $date"
+        echo ""
+
+
+        if [ -z "$issues" ]; then
+            echo "No issues found"
+        else
+            echo "$issues"
+        fi
+
+        echo ""
+        echo "## Pull requests opened after $date"
+        echo ""
+
+        if [ -z "$open_prs" ]; then
+            echo "No pull requests found"
+        else    
+            echo "$open_prs"
+        fi
+
+        echo ""
+        echo "## Pull requests merged after $date"
+        echo ""
+
+        if [ -z "$merged_prs" ]; then
+            echo "No pull requests found"
+        else    
+            echo "$merged_prs"
+        fi
+
+        echo ""
+    done
+}
+
+
+function create_discussion {
+    title=$1
+    body=$2
+
+    repo_id=$(gh api graphql -q '.data.repository.id' -F owner="$repo_owner" -F name="$repo_name" -f query='query
+        FindRepository($owner:String!, $name: String!)
+        {
+            repository(owner:$owner, name:$name) {
+                id
+            }
+        }
+    ')
+
+    category_id=$(gh api graphql -q '.data.repository.discussionCategory.id' -F owner="$repo_owner" -F name="$repo_name" -F category="$category_slug" -f query='query
+        FindCategory($owner:String!, $name:String!, $category: String!)
+        {
+            repository(owner:$owner, name:$name) {
+                discussionCategory(slug:$category) {
+                    id
+                }
+            }
+        }
+    ')
+
+    gh api graphql -F repoId="$repo_id" -F categoryId="$category_id" -F body="$body" -F title="$title" -f query='
+        mutation CreateDiscussion($repoId:ID!, $categoryId:ID!, $body:String!, $title:String!) {
+            createDiscussion(input: {repositoryId: $repoId, categoryId: $categoryId, body: $body, title: $title}) {
+                discussion {
+                    id
+                }
+            }
+        }
+    '
+}
+
+if [ "${DRY_RUN}" = "true" ]; then
+    create_report
+else
+    create_discussion "Issues and PR summary $(date +%Y-%m-%d)" "$(create_report)"
+fi


### PR DESCRIPTION
An example of how to automate the discussion item for the developer meetings. 

To trigger the workflow to create a discussion item, you would use the workflow_dispatch function:

![image](https://github.com/user-attachments/assets/4f46c3b3-dcf5-4da2-8b20-603d93801d51)

~~The resulting discussion would look something like this: https://github.com/lenkan/keri/discussions/8~~

~~Imo, it looks a bit cluttered, it would probably be better if the summary for each repo would be posted as a comment instead of the initial discussion body. You can close this if you want, or suggest changes.~~

Edit: I have update the script to post comments instead. See https://github.com/lenkan/keri/discussions/20